### PR TITLE
feature: `CodeView` extension

### DIFF
--- a/examples/views/AllExtensions.vue
+++ b/examples/views/AllExtensions.vue
@@ -60,7 +60,14 @@ import {
   Preview,
   SelectAll,
   History,
+  CodeView,
 } from 'element-tiptap';
+
+import codemirror from 'codemirror';
+import 'codemirror/lib/codemirror.css'; // import base style
+import 'codemirror/mode/xml/xml.js'; // language
+import 'codemirror/addon/selection/active-line.js'; // require active-line.js
+import 'codemirror/addon/edit/closetag.js'; // autoCloseTags
 
 export default {
   data () {
@@ -114,6 +121,13 @@ export default {
         new Preview(),
         new SelectAll(),
         new Fullscreen(),
+        new CodeView({
+          codemirror,
+          codemirrorOptions: {
+            styleActiveLine: true,
+            autoCloseTags: true,
+          },
+        }),
         new TrailingNode(),
         new History(),
       ],

--- a/examples/views/Simple.vue
+++ b/examples/views/Simple.vue
@@ -32,8 +32,15 @@ import {
   Indent,
   HardBreak,
   HorizontalRule,
+  CodeView,
   History,
 } from 'element-tiptap';
+
+import codemirror from 'codemirror';
+import 'codemirror/lib/codemirror.css'; // import base style
+import 'codemirror/mode/xml/xml.js'; // language
+import 'codemirror/addon/selection/active-line.js'; // require active-line.js
+import 'codemirror/addon/edit/closetag.js'; // autoCloseTags
 
 export default {
   data () {
@@ -60,6 +67,13 @@ export default {
         new Indent(),
         new HardBreak(),
         new HorizontalRule({ bubble: true }),
+        new CodeView({
+          codemirror,
+          codemirrorOptions: {
+            styleActiveLine: true,
+            autoCloseTags: true,
+          },
+        }),
         new History(),
       ],
 

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   ],
   "dependencies": {
     "@juggle/resize-observer": "^3.1.2",
+    "codemirror": "^5.54.0",
     "core-js": "^3.4.3",
     "tiptap": "^1.26.6",
     "tiptap-extensions": "^1.28.6",

--- a/src/components/ElementTiptap.vue
+++ b/src/components/ElementTiptap.vue
@@ -2,7 +2,7 @@
   <div
     v-if="editor"
     :style="elTiptapEditorStyle"
-    :class="{ 'el-tiptap-editor--fullscreen': isFullscreen }"
+    :class="{ 'el-tiptap-editor--fullscreen': editorStateOptions.isFullscreen }"
     class="el-tiptap-editor"
   >
     <menu-bubble
@@ -24,7 +24,16 @@
       </template>
     </menu-bar>
 
+    <div
+      v-if="isCodeViewMode"
+      class="el-tiptap-editor__codemirror"
+    >
+      <textarea ref="cmTextArea"></textarea>
+    </div>
+
+    <!-- use v-show to keep history -->
     <editor-content
+      v-show="!isCodeViewMode"
       :editor="editor"
       class="el-tiptap-editor__content"
     />
@@ -34,7 +43,7 @@
       :editor="editor"
     >
       <div
-        v-if="charCounterCount"
+        v-if="charCounterCount && !isCodeViewMode"
         class="el-tiptap-editor__footer"
       >
         <span class="el-tiptap-editor__characters">
@@ -46,7 +55,7 @@
 </template>
 
 <script lang="ts">
-import { Component, Prop, Watch, Provide, ProvideReactive, Model, Mixins } from 'vue-property-decorator';
+import { Component, Prop, Watch, Provide, Model, Mixins, Vue } from 'vue-property-decorator';
 import { Editor, EditorContent, Extension, EditorUpdateEvent } from 'tiptap';
 import { Placeholder } from 'tiptap-extensions';
 import ContentAttributes from '@/extensions/content_attributes';
@@ -54,7 +63,9 @@ import Title from '@/extensions/title';
 import { capitalize } from '@/utils/shared';
 import { EVENTS } from '@/constants';
 import EditorStylesMixin from '@/mixins/EditorStylesMixin';
+import CodeViewMixin from '@/mixins/CodeViewMixin';
 import i18nMixin from '@/mixins/i18nMixin';
+import { EditorStateOptions } from '@/../types';
 
 import MenuBar from './MenuBar/index.vue';
 import MenuBubble from './MenuBubble/index.vue';
@@ -78,7 +89,7 @@ const COMMON_EMIT_EVENTS: EVENTS[] = [
   // https://github.com/kaorun343/vue-property-decorator/issues/277#issuecomment-558594655
   inject: [],
 })
-export default class ElTiptap extends Mixins(EditorStylesMixin, i18nMixin) {
+export default class ElTiptap extends Mixins(EditorStylesMixin, CodeViewMixin, i18nMixin) {
   @Prop({
     type: Array,
     default: () => [],
@@ -133,6 +144,14 @@ export default class ElTiptap extends Mixins(EditorStylesMixin, i18nMixin) {
     return this.editor.state.doc.textContent.length;
   }
 
+  get spellcheckEnabled (): boolean {
+    return this.spellcheck == null
+      ? this.$elementTiptapPlugin
+        ? this.$elementTiptapPlugin.spellcheck
+        : true
+      : this.spellcheck;
+  }
+
   @Watch('content')
   onContentChange (val: string): void {
     if (this.emitAfterOnUpdate) {
@@ -185,15 +204,9 @@ export default class ElTiptap extends Mixins(EditorStylesMixin, i18nMixin) {
     const extensions: Extension[] = [...this.extensions];
 
     // spellcheck
-    const spellcheck = this.spellcheck == null
-      ? this.$elementTiptapPlugin
-        ? this.$elementTiptapPlugin.spellcheck
-        : true
-      : this.spellcheck;
-
     extensions.push(
       new ContentAttributes({
-        spellcheck,
+        spellcheck: this.spellcheckEnabled,
       }),
     );
 
@@ -239,11 +252,12 @@ export default class ElTiptap extends Mixins(EditorStylesMixin, i18nMixin) {
     this.$emit(this.genEvent(EVENTS.UPDATE), output, options);
   }
 
-  // TODO: provide to fullscreen command button, need to be optimized
-  @ProvideReactive() isFullscreen = false;
-  @Provide() toggleFullscreen () {
-    this.isFullscreen = !this.isFullscreen;
-  }
+  @Provide() get editorStateOptions (): EditorStateOptions {
+    return Vue.observable({
+      isFullscreen: false,
+      isCodeViewMode: false,
+    });
+  };
 
   private genEvent (event: EVENTS) {
     return `on${capitalize(event)}`;

--- a/src/components/MenuBar/index.vue
+++ b/src/components/MenuBar/index.vue
@@ -10,6 +10,7 @@
           :key="'command-button' + i"
           :is="spec.component"
           v-bind="spec.componentProps"
+          :readonly="editorStateOptions.isCodeViewMode"
           v-on="spec.componentEvents"
         />
       </div>
@@ -18,9 +19,9 @@
 </template>
 
 <script lang="ts">
-import { Component, Prop, Vue } from 'vue-property-decorator';
+import { Component, Prop, Vue, Inject } from 'vue-property-decorator';
 import { Editor, EditorMenuBar, MenuData } from 'tiptap';
-import { MenuBtnViewType } from '@/../types';
+import { MenuBtnViewType, EditorStateOptions } from '@/../types';
 
 @Component({
   components: {
@@ -33,6 +34,8 @@ export default class Menubar extends Vue {
     required: true,
   })
   readonly editor!: Editor;
+
+  @Inject() readonly editorStateOptions!: EditorStateOptions;
 
   private generateCommandButtonComponentSpecs (editorContext: MenuData): MenuBtnViewType[] {
     const extensionManager = this.editor.extensions;

--- a/src/components/MenuCommands/CodeViewCommandButton.vue
+++ b/src/components/MenuCommands/CodeViewCommandButton.vue
@@ -1,0 +1,32 @@
+<template>
+  <command-button
+    :command="() => isCodeViewMode = !isCodeViewMode"
+    :tooltip="t('editor.extensions.CodeView.tooltip')"
+    icon="regular/file-code"
+    :is-active="editorStateOptions.isCodeViewMode"
+  />
+</template>
+
+<script lang="ts">
+import { Component, Inject, Mixins } from 'vue-property-decorator';
+import { EditorStateOptions } from '@/../types';
+import i18nMixin from '@/mixins/i18nMixin';
+import CommandButton from './CommandButton.vue';
+
+@Component({
+  components: {
+    CommandButton,
+  },
+})
+export default class CodeViewCommandButton extends Mixins(i18nMixin) {
+  @Inject() readonly editorStateOptions!: EditorStateOptions;
+
+  get isCodeViewMode (): EditorStateOptions['isCodeViewMode'] {
+    return this.editorStateOptions.isCodeViewMode;
+  }
+
+  set isCodeViewMode (val: boolean) {
+    this.editorStateOptions.isCodeViewMode = val;
+  }
+};
+</script>

--- a/src/components/MenuCommands/ColorPopover.vue
+++ b/src/components/MenuCommands/ColorPopover.vue
@@ -1,6 +1,7 @@
 <template>
   <el-popover
     v-model="popoverVisible"
+    :disabled="editorStateOptions.isCodeViewMode"
     placement="bottom"
     trigger="click"
     popper-class="el-tiptap-popper"
@@ -55,12 +56,14 @@
       slot="reference"
       :tooltip="tooltip"
       :icon="icon"
+      :readonly="editorStateOptions.isCodeViewMode"
     />
   </el-popover>
 </template>
 
 <script lang="ts">
-import { Component, Prop, Watch, Emit, Vue } from 'vue-property-decorator';
+import { Component, Prop, Watch, Emit, Vue, Inject } from 'vue-property-decorator';
+import { EditorStateOptions } from '@/../types';
 import { Button, Popover, Input } from 'element-ui';
 import CommandButton from './CommandButton.vue';
 
@@ -105,6 +108,8 @@ export default class ColorPopover extends Vue {
 
   private color: string = '';
   private popoverVisible: boolean = false;
+
+  @Inject() readonly editorStateOptions!: EditorStateOptions;
 
   @Watch('selectedColor', {
     immediate: true,

--- a/src/components/MenuCommands/CommandButton.vue
+++ b/src/components/MenuCommands/CommandButton.vue
@@ -2,6 +2,7 @@
   <el-tooltip
     :content="tooltip"
     :open-delay="350"
+    :disabled="readonly"
     transition="el-zoom-in-bottom"
     effect="dark"
     placement="top"
@@ -9,7 +10,7 @@
     <div
       :class="commandButtonClass"
       @mousedown.prevent
-      @click="command"
+      @click="onClick"
     >
       <v-icon :name="icon"/>
     </div>
@@ -58,6 +59,7 @@ import 'vue-awesome/icons/compress';
 import 'vue-awesome/icons/print';
 import 'vue-awesome/icons/eye';
 import 'vue-awesome/icons/regular/object-group';
+import 'vue-awesome/icons/regular/file-code';
 
 import { Component, Prop, Vue } from 'vue-property-decorator';
 import { Tooltip } from 'element-ui';
@@ -94,11 +96,22 @@ export default class CommandButton extends Vue {
   })
   readonly command!: Function;
 
+  @Prop({
+    type: Boolean,
+    default: false,
+  })
+  readonly readonly!: boolean;
+
   private get commandButtonClass (): object {
     return {
       'el-tiptap-editor__command-button': true,
       'el-tiptap-editor__command-button--active': this.isActive,
+      'el-tiptap-editor__command-button--readonly': this.readonly,
     };
+  }
+
+  onClick () {
+    if (!this.readonly) this.command();
   }
 }
 </script>

--- a/src/components/MenuCommands/FontSizeDropdown.vue
+++ b/src/components/MenuCommands/FontSizeDropdown.vue
@@ -6,6 +6,7 @@
   >
     <command-button
       :tooltip="t('editor.extensions.FontSize.tooltip')"
+      :readonly="editorStateOptions.isCodeViewMode"
       icon="text-width"
     />
 
@@ -40,8 +41,9 @@
 </template>
 
 <script lang="ts">
-import { Component, Prop, Mixins } from 'vue-property-decorator';
+import { Component, Prop, Mixins, Inject } from 'vue-property-decorator';
 import { MenuData } from 'tiptap';
+import { EditorStateOptions } from '@/../types';
 import { Dropdown, DropdownMenu, DropdownItem } from 'element-ui';
 import i18nMixin from '@/mixins/i18nMixin';
 import { DEFAULT_FONT_SIZE, findActiveFontSize } from '@/utils/font_size';
@@ -63,6 +65,8 @@ export default class FontSizeDropdown extends Mixins(i18nMixin) {
   readonly editorContext!: MenuData;
 
   defaultSize = DEFAULT_FONT_SIZE;
+
+  @Inject() readonly editorStateOptions!: EditorStateOptions;
 
   private get editor () {
     return this.editorContext.editor;

--- a/src/components/MenuCommands/FontTypeDropdown.vue
+++ b/src/components/MenuCommands/FontTypeDropdown.vue
@@ -6,6 +6,7 @@
   >
     <command-button
       :tooltip="t('editor.extensions.FontType.tooltip')"
+      :readonly="editorStateOptions.isCodeViewMode"
       icon="font"
     />
 
@@ -32,8 +33,9 @@
 </template>
 
 <script lang="ts">
-import { Component, Prop, Mixins } from 'vue-property-decorator';
+import { Component, Prop, Mixins, Inject } from 'vue-property-decorator';
 import { MenuData } from 'tiptap';
+import { EditorStateOptions } from '@/../types';
 import { Dropdown, DropdownMenu, DropdownItem } from 'element-ui';
 import i18nMixin from '@/mixins/i18nMixin';
 import { DEFAULT_FONT_TYPE_MAP, findActiveFontType } from '@/utils/font_type';
@@ -55,6 +57,8 @@ export default class FontTypeDropdown extends Mixins(i18nMixin) {
     required: true,
   })
   readonly editorContext!: MenuData;
+
+  @Inject() readonly editorStateOptions!: EditorStateOptions;
 
   private get editor () {
     return this.editorContext.editor;

--- a/src/components/MenuCommands/FullscreenCommandButton.vue
+++ b/src/components/MenuCommands/FullscreenCommandButton.vue
@@ -1,6 +1,6 @@
 <template>
   <command-button
-    :command="toggleFullscreen"
+    :command="() => isFullscreen = !isFullscreen"
     :tooltip="buttonTooltip"
     :icon="isFullscreen ? 'compress' : 'expand'"
     :is-active="isFullscreen"
@@ -8,7 +8,8 @@
 </template>
 
 <script lang="ts">
-import { Component, Inject, InjectReactive, Mixins } from 'vue-property-decorator';
+import { Component, Inject, Mixins } from 'vue-property-decorator';
+import { EditorStateOptions } from '@/../types';
 import i18nMixin from '@/mixins/i18nMixin';
 import CommandButton from './CommandButton.vue';
 
@@ -18,8 +19,16 @@ import CommandButton from './CommandButton.vue';
   },
 })
 export default class FullscreenCommandButton extends Mixins(i18nMixin) {
-  @Inject() readonly toggleFullscreen!: Function;
-  @InjectReactive() readonly isFullscreen!: boolean;
+  @Inject() readonly editorStateOptions!: EditorStateOptions;
+
+  get isFullscreen (): EditorStateOptions['isFullscreen'] {
+    return this.editorStateOptions.isFullscreen;
+  }
+
+  set isFullscreen (val: boolean) {
+    // eslint-disable-next-line no-debugger
+    this.editorStateOptions.isFullscreen = val;
+  }
 
   private get buttonTooltip () {
     return this.isFullscreen

--- a/src/components/MenuCommands/HeadingDropdown.vue
+++ b/src/components/MenuCommands/HeadingDropdown.vue
@@ -10,6 +10,7 @@
     <command-button
       :is-active="isHeadingActive()"
       :tooltip="t('editor.extensions.Heading.tooltip')"
+      :readonly="editorStateOptions.isCodeViewMode"
       icon="heading"
     />
     <el-dropdown-menu
@@ -46,11 +47,12 @@
 </template>
 
 <script lang="ts">
-import { Component, Prop, Mixins } from 'vue-property-decorator';
+import { Component, Prop, Mixins, Inject } from 'vue-property-decorator';
 import { MenuData } from 'tiptap';
 import { Dropdown, DropdownMenu, DropdownItem } from 'element-ui';
 import i18nMixin from '@/mixins/i18nMixin';
 import { isHeadingActive } from '@/utils/heading';
+import { EditorStateOptions } from '@/../types';
 import CommandButton from './CommandButton.vue';
 
 @Component({
@@ -67,6 +69,8 @@ export default class HeadingDropdown extends Mixins(i18nMixin) {
     required: true,
   })
   readonly editorContext!: MenuData;
+
+  @Inject() readonly editorStateOptions!: EditorStateOptions;
 
   private get editor () {
     return this.editorContext.editor;

--- a/src/components/MenuCommands/IframeCommandButton.vue
+++ b/src/components/MenuCommands/IframeCommandButton.vue
@@ -2,14 +2,16 @@
   <command-button
     :command="openInsertVideoControl"
     :tooltip="t('editor.extensions.Iframe.tooltip')"
+    :readonly="editorStateOptions.isCodeViewMode"
     icon="video"
   />
 </template>
 
 <script lang="ts">
-import { Component, Prop, Mixins } from 'vue-property-decorator';
+import { Component, Prop, Mixins, Inject } from 'vue-property-decorator';
 import { MessageBox } from 'element-ui';
 import { MenuData } from 'tiptap';
+import { EditorStateOptions } from '@/../types';
 import i18nMixin from '@/mixins/i18nMixin';
 import CommandButton from './CommandButton.vue';
 
@@ -24,6 +26,8 @@ export default class IframeCommandButton extends Mixins(i18nMixin) {
     required: true,
   })
   readonly editorContext!: MenuData;
+
+  @Inject() readonly editorStateOptions!: EditorStateOptions;
 
   openInsertVideoControl (): void {
     MessageBox.prompt('', this.t('editor.extensions.Iframe.control.title'), {

--- a/src/components/MenuCommands/Image/InsertImageCommandButton.vue
+++ b/src/components/MenuCommands/Image/InsertImageCommandButton.vue
@@ -1,6 +1,7 @@
 <template>
   <div>
     <el-popover
+      :disabled="editorStateOptions.isCodeViewMode"
       placement="bottom"
       trigger="click"
       popper-class="el-tiptap-popper"
@@ -24,6 +25,7 @@
       <command-button
         slot="reference"
         :tooltip="t('editor.extensions.Image.buttons.insert_image.tooltip')"
+        :readonly="editorStateOptions.isCodeViewMode"
         icon="image"
       />
     </el-popover>
@@ -53,10 +55,11 @@
 </template>
 
 <script lang="ts">
-import { Component, Prop, Mixins } from 'vue-property-decorator';
+import { Component, Prop, Mixins, Inject } from 'vue-property-decorator';
 import { Dialog, Upload, MessageBox, Popover, Loading } from 'element-ui';
 import { HttpRequestOptions } from 'element-ui/types/upload';
 import { MenuData } from 'tiptap';
+import { EditorStateOptions } from '@/../types';
 import i18nMixin from '@/mixins/i18nMixin';
 import { readFileDataUrl } from '@/utils/shared';
 import Logger from '@/utils/logger';
@@ -79,6 +82,8 @@ export default class ImageCommandButton extends Mixins(i18nMixin) {
 
   imageUploadDialogVisible = false;
   uploading = false;
+
+  @Inject() readonly editorStateOptions!: EditorStateOptions;
 
   private get imageNodeOptions () {
     return this.editorContext.editor.extensions.options.image;

--- a/src/components/MenuCommands/LineHeightDropdown.vue
+++ b/src/components/MenuCommands/LineHeightDropdown.vue
@@ -6,6 +6,7 @@
   >
     <command-button
       :tooltip="t('editor.extensions.LineHeight.tooltip')"
+      :readonly="editorStateOptions.isCodeViewMode"
       icon="text-height"
     />
     <el-dropdown-menu
@@ -28,8 +29,9 @@
 </template>
 
 <script lang="ts">
-import { Component, Prop, Mixins } from 'vue-property-decorator';
+import { Component, Prop, Mixins, Inject } from 'vue-property-decorator';
 import { MenuData } from 'tiptap';
+import { EditorStateOptions } from '@/../types';
 import { Dropdown, DropdownMenu, DropdownItem } from 'element-ui';
 import i18nMixin from '@/mixins/i18nMixin';
 import { isLineHeightActive } from '@/utils/line_height';
@@ -49,6 +51,8 @@ export default class LineHeightDropdown extends Mixins(i18nMixin) {
     required: true,
   })
   readonly editorContext!: MenuData;
+
+  @Inject() readonly editorStateOptions!: EditorStateOptions;
 
   private get editor () {
     return this.editorContext.editor;

--- a/src/components/MenuCommands/Link/AddLinkCommandButton.vue
+++ b/src/components/MenuCommands/Link/AddLinkCommandButton.vue
@@ -1,6 +1,7 @@
 <template>
   <command-button
     :is-active="editorContext.isActive.link()"
+    :readonly="editorStateOptions.isCodeViewMode"
     :command="openApplyLinkControl"
     :tooltip="t('editor.extensions.Link.add.tooltip')"
     icon="link"
@@ -8,9 +9,10 @@
 </template>
 
 <script lang="ts">
-import { Component, Prop, Mixins } from 'vue-property-decorator';
+import { Component, Prop, Mixins, Inject } from 'vue-property-decorator';
 import { MessageBox } from 'element-ui';
 import { MenuData } from 'tiptap';
+import { EditorStateOptions } from '@/../types';
 import i18nMixin from '@/mixins/i18nMixin';
 import CommandButton from '../CommandButton.vue';
 
@@ -25,6 +27,8 @@ export default class AddLinkCommandButton extends Mixins(i18nMixin) {
     required: true,
   })
   readonly editorContext!: MenuData;
+
+  @Inject() readonly editorStateOptions!: EditorStateOptions;
 
   openApplyLinkControl (): void {
     MessageBox.prompt('', this.t('editor.extensions.Link.add.control.title'), {

--- a/src/components/MenuCommands/PreviewCommandButton.vue
+++ b/src/components/MenuCommands/PreviewCommandButton.vue
@@ -3,6 +3,7 @@
     <command-button
       :command="togglePreviewDialogVisible"
       :tooltip="t('editor.extensions.Preview.tooltip')"
+      :readonly="editorStateOptions.isCodeViewMode"
       icon="eye"
     />
 
@@ -20,9 +21,10 @@
 </template>
 
 <script lang="ts">
-import { Component, Prop, Watch, Mixins } from 'vue-property-decorator';
+import { Component, Prop, Watch, Mixins, Inject } from 'vue-property-decorator';
 import { Dialog } from 'element-ui';
 import { MenuData } from 'tiptap';
+import { EditorStateOptions } from '@/../types';
 import { PREVIEW_WINDOW_WIDTH } from '@/constants';
 import i18nMixin from '@/mixins/i18nMixin';
 import CommandButton from './CommandButton.vue';
@@ -48,6 +50,8 @@ export default class PreviewCommandButton extends Mixins(i18nMixin) {
 
   html: string = '';
   previewDialogVisible: boolean = false;
+
+  @Inject() readonly editorStateOptions!: EditorStateOptions;
 
   @Watch('previewDialogVisible')
   onVisibleChange (visible: boolean) {

--- a/src/components/MenuCommands/TablePopover/index.vue
+++ b/src/components/MenuCommands/TablePopover/index.vue
@@ -1,6 +1,7 @@
 <template>
   <el-popover
     v-model="popoverVisible"
+    :disabled="editorStateOptions.isCodeViewMode"
     placement="bottom"
     trigger="click"
     popper-class="el-tiptap-popper"
@@ -106,14 +107,16 @@
       slot="reference"
       :is-active="isTableActive"
       :tooltip="t('editor.extensions.Table.tooltip')"
+      :readonly="editorStateOptions.isCodeViewMode"
       icon="table"
     />
   </el-popover>
 </template>
 
 <script lang="ts">
-import { Component, Prop, Mixins } from 'vue-property-decorator';
+import { Component, Prop, Mixins, Inject } from 'vue-property-decorator';
 import { MenuData } from 'tiptap';
+import { EditorStateOptions } from '@/../types';
 import { Popover } from 'element-ui';
 import { isTableActive, enableMergeCells, enableSplitCell } from '@/utils/table';
 import i18nMixin from '@/mixins/i18nMixin';
@@ -135,6 +138,8 @@ export default class TablePopover extends Mixins(i18nMixin) {
   readonly editorContext!: MenuData;
 
   private popoverVisible: boolean = false;
+
+  @Inject() readonly editorStateOptions!: EditorStateOptions;
 
   private get editor () {
     return this.editorContext.editor;

--- a/src/extensions/code_view.ts
+++ b/src/extensions/code_view.ts
@@ -1,0 +1,55 @@
+import { Extension } from 'tiptap';
+import { MenuBtnView } from '@/../types';
+import CodeViewCommandButton from '@/components/MenuCommands/CodeViewCommandButton.vue';
+import { extendCodemirror } from '@/utils/code_view';
+import Logger from '@/utils/logger';
+
+export const DEFAULT_CODEMIRROR_OPTIONS = {
+  lineNumbers: true,
+  lineWrapping: true,
+  tabSize: 2,
+  tabMode: 'indent',
+  mode: 'text/html',
+};
+
+export default class CodeView extends Extension implements MenuBtnView {
+  constructor (options = {}) {
+    super(options);
+
+    // @ts-ignore
+    const { codemirror } = options;
+    if (codemirror == null) {
+      Logger.warn('`CodeView` extension requires the CodeMirror library.');
+    } else {
+      extendCodemirror(codemirror);
+    }
+
+    this.options = {
+      codemirror,
+      codemirrorOptions: {
+        ...this.defaultOptions.codemirrorOptions,
+        // @ts-ignore
+        ...options.codemirrorOptions,
+      },
+    };
+  }
+
+  get name () {
+    return 'code_view';
+  }
+
+  get defaultOptions () {
+    return {
+      codemirror: null,
+      codemirrorOptions: {
+        ...DEFAULT_CODEMIRROR_OPTIONS,
+      },
+    };
+  }
+
+  menuBtnView () {
+    return {
+      component: CodeViewCommandButton,
+    };
+  }
+}

--- a/src/extensions/index.ts
+++ b/src/extensions/index.ts
@@ -47,3 +47,4 @@ export { default as Fullscreen } from './fullscreen';
 export { default as Print } from './print';
 export { default as Preview } from './preview';
 export { default as SelectAll } from './select_all';
+export { default as CodeView } from './code_view';

--- a/src/i18n/de/index.ts
+++ b/src/i18n/de/index.ts
@@ -203,6 +203,9 @@ export default {
       SelectAll: {
         tooltip: 'Alles auswählen',
       },
+      CodeView: {
+        tooltip: 'Codeansicht',
+      },
     },
     characters: 'Zeichen',
   },

--- a/src/i18n/en/index.ts
+++ b/src/i18n/en/index.ts
@@ -203,6 +203,9 @@ export default {
       SelectAll: {
         tooltip: 'Select all',
       },
+      CodeView: {
+        tooltip: 'Code view',
+      },
     },
     characters: 'Characters',
   },

--- a/src/i18n/es/index.ts
+++ b/src/i18n/es/index.ts
@@ -203,6 +203,9 @@ export default {
       SelectAll: {
         tooltip: 'Seleccionar todo',
       },
+      CodeView: {
+        tooltip: 'Vista de código',
+      },
     },
     characters: 'Caracteres',
   },

--- a/src/i18n/ko/index.ts
+++ b/src/i18n/ko/index.ts
@@ -203,6 +203,9 @@ export default {
       SelectAll: {
         tooltip: '전체선택',
       },
+      CodeView: {
+        tooltip: '코드 뷰',
+      },
     },
     characters: '문자수',
   },

--- a/src/i18n/pl/index.ts
+++ b/src/i18n/pl/index.ts
@@ -203,6 +203,9 @@ export default {
       SelectAll: {
         tooltip: 'Zaznacz wszystko',
       },
+      CodeView: {
+        tooltip: 'Widok kodu',
+      },
     },
     characters: 'Znaki',
   },

--- a/src/i18n/ru/index.ts
+++ b/src/i18n/ru/index.ts
@@ -203,6 +203,9 @@ export default {
       SelectAll: {
         tooltip: 'Выделить все',
       },
+      CodeView: {
+        tooltip: 'Просмотр кода',
+      },
     },
     characters: 'Количество символов',
   },

--- a/src/i18n/zh/index.ts
+++ b/src/i18n/zh/index.ts
@@ -203,6 +203,9 @@ export default {
       SelectAll: {
         tooltip: '全选',
       },
+      CodeView: {
+        tooltip: '查看源代码',
+      },
     },
     characters: '字数',
   },

--- a/src/mixins/CodeViewMixin.ts
+++ b/src/mixins/CodeViewMixin.ts
@@ -1,0 +1,60 @@
+// @ts-nocheck
+import { Component, Vue, Watch } from 'vue-property-decorator';
+import { EditorStateOptions } from '@/../types';
+
+@Component
+export default class CodeViewMixin extends Vue {
+  cmInstance = null;
+
+  get isCodeViewMode (): EditorStateOptions['isCodeViewMode'] {
+    return this.editorStateOptions.isCodeViewMode;
+  }
+
+  @Watch('isCodeViewMode')
+  onCodeViewModeChange (val: boolean): void {
+    if (val) {
+      this.$nextTick(() => !this.cmInstance && this.initCodemirror());
+    } else { // update editor content
+      if (this.cmInstance) {
+        const content = this.cmInstance.getValue();
+        this.editor.setContent(content, true /* emitUpdate */);
+        this.destroyCodemirror();
+      }
+    }
+  }
+
+  private initCodemirror () {
+    const codeView = this.extensions.find(e => e.name === 'code_view');
+    if (codeView) {
+      const { codemirror, codemirrorOptions } = codeView.options;
+      if (codemirror) {
+        // merge options
+        const cmOptions = {
+          ...codemirrorOptions,
+          readOnly: this.readonly,
+          spellcheck: this.spellcheckEnabled,
+        };
+        this.cmInstance = codemirror.fromTextArea(this.$refs.cmTextArea, cmOptions);
+        this.cmInstance.setValue(this.editor.getHTML()); // init content
+        this.formatCode();
+      }
+    }
+  }
+
+  private destroyCodemirror () {
+    const element = this.cmInstance.doc.cm.getWrapperElement();
+    element && element.remove && element.remove();
+    this.cmInstance = null;
+  }
+
+  private formatCode () {
+    const cm = this.cmInstance;
+    cm.execCommand('selectAll');
+    const selectedRange = {
+      from: cm.getCursor(true),
+      to: cm.getCursor(false),
+    };
+    cm.autoFormatRange(selectedRange.from, selectedRange.to);
+    cm.setCursor(0);
+  }
+}

--- a/src/styles/command_button.scss
+++ b/src/styles/command_button.scss
@@ -26,6 +26,16 @@
       background-color: $extra-light-primary-color;
       color: $primary-color;
     }
+
+    &--readonly {
+      cursor: default;
+      opacity: .3;
+      pointer-events: none;
+
+      &:hover {
+        background-color: transparent;
+      }
+    }
   }
 }
 

--- a/src/styles/editor.scss
+++ b/src/styles/editor.scss
@@ -12,6 +12,22 @@
   position: relative;
   width: 100%;
 
+  * {
+    box-sizing: border-box;
+  }
+
+  &__codemirror {
+    display: flex;
+    flex-grow: 1;
+    font-size: 16px;
+    line-height: 24px;
+
+    .CodeMirror {
+      flex-grow: 1;
+      height: auto;
+    }
+  }
+
   &--fullscreen {
     border-radius: 0 !important;
     bottom: 0 !important;

--- a/src/utils/code_view.ts
+++ b/src/utils/code_view.ts
@@ -1,0 +1,60 @@
+// @ts-nocheck
+// https://github.com/artf/codemirror-formatting/blob/master/formatting.js
+
+const inlineElements = /^(a|abbr|acronym|area|base|bdo|big|br|button|caption|cite|code|col|colgroup|dd|del|dfn|em|frame|hr|iframe|img|input|ins|kbd|label|legend|link|map|object|optgroup|option|param|q|samp|script|select|small|span|strong|sub|sup|textarea|tt|var)$/;
+
+// for format code
+export function extendCodemirror (CodeMirror) {
+  CodeMirror.extendMode('xml', {
+    newlineAfterToken: function (type, content, textAfter, state) {
+      let inline = false;
+      if (this.configuration === 'html') {
+        inline = state.context ? inlineElements.test(state.context.tagName) : false;
+      }
+      return !inline && ((type === 'tag' && />$/.test(content) && state.context) ||
+        /^</.test(textAfter));
+    }
+  });
+
+  CodeMirror.defineExtension('autoFormatRange', function (from, to) {
+    const cm = this;
+    const outer = cm.getMode();
+    const text = cm.getRange(from, to).split('\n');
+    const state = CodeMirror.copyState(outer, cm.getTokenAt(from).state);
+    const tabSize = cm.getOption('tabSize');
+
+    let out = '';
+    let lines = 0;
+    let atSol = from.ch === 0;
+
+    function newline () {
+      out += '\n';
+      atSol = true;
+      ++lines;
+    }
+
+    for (let i = 0; i < text.length; ++i) {
+      const stream = new CodeMirror.StringStream(text[i], tabSize);
+      while (!stream.eol()) {
+        const inner = CodeMirror.innerMode(outer, state);
+        const style = outer.token(stream, state);
+        const cur = stream.current();
+        stream.start = stream.pos;
+        if (!atSol || /\S/.test(cur)) {
+          out += cur;
+          atSol = false;
+        }
+        if (!atSol && inner.mode.newlineAfterToken &&
+          inner.mode.newlineAfterToken(style, cur, stream.string.slice(stream.pos) || text[i + 1] || '', inner.state)) { newline(); }
+      }
+      if (!stream.pos && outer.blankLine) outer.blankLine(state);
+      if (!atSol && i < text.length - 1) newline();
+    }
+
+    cm.operation(function () {
+      cm.replaceRange(out, from, to);
+      for (let cur = from.line + 1, end = from.line + lines; cur <= end; ++cur) { cm.indentLine(cur, 'smart'); }
+      cm.setSelection(from, cm.getCursor(false));
+    });
+  });
+}

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -17,6 +17,11 @@ export interface MenuBtnComponentOptions {
   componentEvents?: { [key: string]: any };
 }
 
+export interface EditorStateOptions {
+  isFullscreen: boolean;
+  isCodeViewMode: boolean;
+}
+
 export type MenuBtnViewType = MenuBtnComponentOptions | MenuBtnComponentOptions[];
 
 export interface MenuBtnView {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3743,6 +3743,11 @@ code-point-at@^1.0.0:
   resolved "https://registry.npm.taobao.org/code-point-at/download/code-point-at-1.1.0.tgz#0d070b4d043a5bea33a2f1a40e2edb3d9a4ccf77"
   integrity sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=
 
+codemirror@^5.54.0:
+  version "5.54.0"
+  resolved "https://registry.yarnpkg.com/codemirror/-/codemirror-5.54.0.tgz#82b6adf662b29eeb7b867fe7839d49e25e4a0b38"
+  integrity sha512-Pgf3surv4zvw+KaW3doUU7pGjF0BPU8/sj7eglWJjzni46U/DDW8pu3nZY0QgQKUcICDXRkq8jZmq0y6KhxM3Q==
+
 collection-visit@^1.0.0:
   version "1.0.0"
   resolved "https://registry.npm.taobao.org/collection-visit/download/collection-visit-1.0.0.tgz#4bc0373c164bc3291b4d368c829cf1a80a59dca0"
@@ -4547,7 +4552,7 @@ decode-uri-component@^0.2.0:
 
 dedent@^0.7.0:
   version "0.7.0"
-  resolved "https://registry.npm.taobao.org/dedent/download/dedent-0.7.0.tgz#2495ddbaf6eb874abb0e1be9df22d2e5a544326c"
+  resolved "https://registry.yarnpkg.com/dedent/-/dedent-0.7.0.tgz#2495ddbaf6eb874abb0e1be9df22d2e5a544326c"
   integrity sha1-JJXduvbrh0q7Dhvp3yLS5aVEMmw=
 
 deep-equal@^1.0.1:


### PR DESCRIPTION
https://github.com/Leecason/element-tiptap/issues/81

# `CodeView` extension

An extension to view and edit HTML source code.

❗This extension requires the `codemirror` library, please install `codemirror` in your project.❗

## usage
```js
import { CodeView } from 'element-tiptap';
import codemirror from 'codemirror'; // install 'codemirror' in your own project

import 'codemirror/lib/codemirror.css'; // import base style
import 'codemirror/mode/xml/xml.js'; // language

data () {
  return {
    extensions: [
      ...
      new CodeView({
        codemirror:  // the CodeMirror library.
        codemirrorOptions: // specify the options for CodeMirror.
      }),
    ],
  };
}
```

default `codemirrorOptions`:

```js
{
  lineNumbers: true,
  lineWrapping: true,
  tabSize: 2,
  tabMode: 'indent',
  mode: 'text/html',
}
```

check more codemirror [options](https://codemirror.net/doc/manual.html#config)

