### PR TITLE
fix: add mac fontSize type 

### DIFF
--- a/src/utils/font_size.ts
+++ b/src/utils/font_size.ts
@@ -22,7 +22,7 @@ export const DEFAULT_FONT_SIZES = [
 
 export const DEFAULT_FONT_SIZE = 'default';
 
-const SIZE_PATTERN = /([\d.]+)px/i;
+const SIZE_PATTERN = /([\d.]+)(px|pt)/i;
 
 export function convertToPX (styleValue: string): string {
   const matches = styleValue.match(SIZE_PATTERN);


### PR DESCRIPTION
fix: add mac fontSize type (https://github.com/Leecason/element-tiptap/issues/1