### PR TITLE
fix error when import ElementTiptapPlugin from element-tiptap

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,6 +1,6 @@
 import { VueConstructor } from 'vue';
 
-export * from './extensions';
+export * as ElementTiptapPlugin from './extensions';
 
 export interface OptionsInterface {
   lang?: string;


### PR DESCRIPTION
When someone wants to import below plugin, use

import { ElementTiptapPlugin } from 'element-tiptap';

But it will occur error: Module '"../node_modules/element-tiptap/lab"' has no exported member 'ElementTiptapPlugin'.ts