### PR TITLE
fix: pasting text from MS office which have as unit of size pt

### DIFF
--- a/src/utils/font_size.ts
+++ b/src/utils/font_size.ts
@@ -29,6 +29,9 @@ export function convertToPX (styleValue: string): string {
   if (!matches) return '';
   const value = matches[1];
   if (!value) return '';
+  if (matches[2] === 'pt') {
+    return `${(parseInt(value, 10) * 4) / 3}`;
+  }
   return value;
 }
 

--- a/src/utils/font_size.ts
+++ b/src/utils/font_size.ts
@@ -22,7 +22,7 @@ export const DEFAULT_FONT_SIZES = [
 
 export const DEFAULT_FONT_SIZE = 'default';
 
-const SIZE_PATTERN = /([\d.]+)px/i;
+const SIZE_PATTERN = /([\d.]+)(px|pt)/i;
 
 export function convertToPX (styleValue: string): string {
   const matches = styleValue.match(SIZE_PATTERN);


### PR DESCRIPTION
I fix problem described in issue #170 , which related to unit type which MS office have as default one, I test it and it work now as expected