### PR TITLE
Fix small mistake in Readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,13 +43,13 @@ English | [简体中文](./README_ZH.md)
 ### NPM
 
 ```shell
-yarn add element-tiptap
+npm install --save element-tiptap
 ```
 
-Or
+### Or Yarn
 
 ```shell
-npm install --save element-tiptap
+yarn add element-tiptap
 ```
 
 #### Install plugin


### PR DESCRIPTION
The heading said "Yarn" but the install instructions were for npm. I just switched them around.